### PR TITLE
fix:set height to 0 on ios keyboard hide

### DIFF
--- a/packages/soft-keyboard/index.ios.ts
+++ b/packages/soft-keyboard/index.ios.ts
@@ -10,6 +10,12 @@ Application.ios.addNotificationObserver(UIKeyboardDidShowNotification, (event) =
   }
 });
 
+Application.ios.addNotificationObserver(UIKeyboardDidHideNotification, (event) => {
+  if (softKeyboardCallback !== null) {
+    softKeyboardCallback(0);
+  }
+});
+
 export function registerSoftKeyboardCallback(callback: SoftKeyboardCallbackFnType) {
   softKeyboardCallback = callback;
 }


### PR DESCRIPTION
## What is the current behavior?
When keyboard is hidden on iOS, callback is not triggered.

## What is the new behavior?
When keyboard is hidden on iOS, height is set to 0 and callback is called.

